### PR TITLE
Add Pac-Man clone in vanilla JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tetris</title>
+  <title>Pac-Man Clone</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="score">Lines: 0</div>
-  <canvas id="game"></canvas>
+  <div id="hud">
+    <div id="score">Score: 0</div>
+    <div id="lives">Lives: 3</div>
+  </div>
+  <canvas id="game" width="560" height="620"></canvas>
   <div id="controls">
+    <button id="up">▲</button>
     <button id="left">◀</button>
-    <button id="rotate">⟳</button>
-    <button id="right">▶</button>
     <button id="down">▼</button>
+    <button id="right">▶</button>
   </div>
   <div id="message"></div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,227 +1,276 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
+const TILE = 20; // 28x31 grid
 
-let COLS = 10;
-let ROWS = 20;
-let BLOCK = 30;
+// Directions
+const DIRS = {
+  ArrowUp: {x: 0, y: -1},
+  ArrowDown: {x: 0, y: 1},
+  ArrowLeft: {x: -1, y: 0},
+  ArrowRight: {x: 1, y: 0},
+  w: {x: 0, y: -1},
+  s: {x: 0, y: 1},
+  a: {x: -1, y: 0},
+  d: {x: 1, y: 0}
+};
 
-function resize() {
-  BLOCK = Math.floor(Math.min(window.innerWidth / COLS, (window.innerHeight-150) / ROWS));
-  canvas.width = COLS * BLOCK;
-  canvas.height = ROWS * BLOCK;
-}
-window.addEventListener('resize', resize);
-resize();
-
-const COLORS = [null, 'cyan', 'blue', 'orange', 'yellow', 'green', 'purple', 'red'];
-
-const SHAPES = [
-  [
-    [0,0,0,0],
-    [1,1,1,1],
-    [0,0,0,0],
-    [0,0,0,0]
-  ],
-  [
-    [2,0,0],
-    [2,2,2],
-    [0,0,0]
-  ],
-  [
-    [0,0,3],
-    [3,3,3],
-    [0,0,0]
-  ],
-  [
-    [4,4],
-    [4,4]
-  ],
-  [
-    [0,5,5],
-    [5,5,0],
-    [0,0,0]
-  ],
-  [
-    [0,6,0],
-    [6,6,6],
-    [0,0,0]
-  ],
-  [
-    [7,7,0],
-    [0,7,7],
-    [0,0,0]
-  ]
-];
-
-function rotate(matrix) {
-  const N = matrix.length;
-  const result = [];
-  for (let y=0;y<N;y++) {
-    result[y] = [];
-    for (let x=0;x<N;x++) {
-      result[y][x] = matrix[N-1-x][y] || 0;
+// Simple map generator
+function createMap() {
+  const map = [];
+  for (let y = 0; y < 31; y++) {
+    const row = [];
+    for (let x = 0; x < 28; x++) {
+      if (y === 0 || y === 30 || x === 0 || x === 27) row.push(0); else row.push(1);
+    }
+    map.push(row);
+  }
+  // inner walls
+  for (let y = 4; y < 27; y += 6) {
+    for (let x = 4; x < 23; x += 6) {
+      map[y][x] = 0;
+      map[y][x+1] = 0;
+      map[y+1][x] = 0;
     }
   }
-  return result;
+  // ghost door
+  map[15][13] = 4;
+  map[15][14] = 4;
+  // big pellets
+  map[1][1] = 3;
+  map[1][26] = 3;
+  map[29][1] = 3;
+  map[29][26] = 3;
+  return map;
 }
 
-let board = [];
-for (let r=0;r<ROWS;r++) {
-  board[r] = Array(COLS).fill(0);
-}
+const level = createMap();
+let remainingPellets = level.flat().filter(v => v === 1 || v === 3).length;
 
-let current = null;
-let pieceCount = 0;
-let lines = 0;
-let dropCounter = 0;
-let dropInterval = 500;
+const pacman = {
+  x: 14 * TILE,
+  y: 23 * TILE,
+  dir: {x: 0, y: 0},
+  next: {x: 0, y: 0},
+  lives: 3,
+  score: 0
+};
+
+document.getElementById('lives').textContent = `Lives: ${pacman.lives}`;
+
+
+const ghosts = [
+  { x: 13 * TILE, y: 14 * TILE, color: 'red', dir: {x: 1, y: 0}, start: {x: 13, y: 14}, frightened: false, dead: false },
+  { x: 14 * TILE, y: 14 * TILE, color: 'pink', dir: {x: -1, y: 0}, start: {x: 14, y: 14}, frightened: false, dead: false },
+  { x: 13 * TILE, y: 15 * TILE, color: 'cyan', dir: {x: 1, y: 0}, start: {x: 13, y: 15}, frightened: false, dead: false },
+  { x: 14 * TILE, y: 15 * TILE, color: 'orange', dir: {x: -1, y: 0}, start: {x: 14, y: 15}, frightened: false, dead: false }
+];
+
+let powerTimer = 0;
 let lastTime = 0;
 let playing = true;
 
-function spawn() {
-  if (pieceCount >= 100) {
-    playing = false;
-    document.getElementById('message').textContent = 'Fine del gioco';
-    return;
+function tileAt(x, y) {
+  const cx = Math.floor(x / TILE);
+  const cy = Math.floor(y / TILE);
+  return level[cy] && level[cy][cx];
+}
+
+function canMove(x, y) {
+  const t = tileAt(x, y);
+  return t !== 0 && t !== 4;
+}
+
+function moveEntity(entity, speed) {
+  const nx = entity.x + entity.dir.x * speed;
+  const ny = entity.y + entity.dir.y * speed;
+  if (entity.x % TILE === 0 && entity.y % TILE === 0) {
+    // choose new direction if blocked
+    if (!canMove(nx + entity.dir.x * (TILE - 1), ny + entity.dir.y * (TILE - 1))) {
+      entity.dir = {x: 0, y: 0};
+    }
+    if (entity.next && canMove(entity.x + entity.next.x * TILE, entity.y + entity.next.y * TILE)) {
+      entity.dir = entity.next;
+    }
   }
-  const id = Math.floor(Math.random()*SHAPES.length);
-  const shape = SHAPES[id];
-  current = {
-    x: Math.floor((COLS - shape[0].length)/2),
-    y: 0,
-    shape: shape,
-    id: id+1
-  };
-  pieceCount++;
-  if (collide(board, current)) {
-    playing = false;
-    document.getElementById('message').textContent = 'Game Over';
+  if (canMove(nx, ny)) {
+    entity.x = nx;
+    entity.y = ny;
   }
 }
 
-function collide(board, piece) {
-  const {shape, x:ox, y:oy} = piece;
-  for (let y=0;y<shape.length;y++) {
-    for (let x=0;x<shape[y].length;x++) {
-      if (shape[y][x]) {
-        const px = ox + x;
-        const py = oy + y;
-        if (px < 0 || px >= COLS || py >= ROWS) return true;
-        if (py >=0 && board[py][px]) return true;
+function drawMap() {
+  for (let y = 0; y < level.length; y++) {
+    for (let x = 0; x < level[y].length; x++) {
+      const val = level[y][x];
+      if (val === 0) {
+        ctx.fillStyle = '#0033ff';
+        ctx.fillRect(x * TILE, y * TILE, TILE, TILE);
+      } else if (val === 1) {
+        ctx.fillStyle = '#fff';
+        ctx.beginPath();
+        ctx.arc(x * TILE + TILE / 2, y * TILE + TILE / 2, 3, 0, Math.PI * 2);
+        ctx.fill();
+      } else if (val === 3) {
+        ctx.fillStyle = '#fff';
+        ctx.beginPath();
+        ctx.arc(x * TILE + TILE / 2, y * TILE + TILE / 2, 6, 0, Math.PI * 2);
+        ctx.fill();
       }
     }
   }
-  return false;
 }
 
-function merge(board, piece) {
-  piece.shape.forEach((row,y)=>{
-    row.forEach((value,x)=>{
-      if (value && piece.y + y >= 0) {
-        board[piece.y+y][piece.x+x] = piece.id;
-      }
-    });
+function drawPacman() {
+  ctx.fillStyle = 'yellow';
+  ctx.beginPath();
+  let angle = Math.PI / 4;
+  if (pacman.dir.x === 1) angle = Math.PI / 4;
+  else if (pacman.dir.x === -1) angle = (5 * Math.PI) / 4;
+  else if (pacman.dir.y === -1) angle = (7 * Math.PI) / 4;
+  else if (pacman.dir.y === 1) angle = (3 * Math.PI) / 4;
+  ctx.arc(pacman.x + TILE / 2, pacman.y + TILE / 2, TILE / 2 - 2, angle, angle + Math.PI * 1.5);
+  ctx.lineTo(pacman.x + TILE / 2, pacman.y + TILE / 2);
+  ctx.fill();
+}
+
+function drawGhost(g) {
+  ctx.fillStyle = g.frightened ? 'blue' : g.color;
+  ctx.fillRect(g.x, g.y, TILE, TILE);
+}
+
+function resetPositions() {
+  pacman.x = 14 * TILE;
+  pacman.y = 23 * TILE;
+  pacman.dir = {x: 0, y: 0};
+  pacman.next = {x: 0, y: 0};
+  ghosts.forEach(g => {
+    g.x = g.start.x * TILE;
+    g.y = g.start.y * TILE;
+    g.dir = {x: 0, y: 0};
+    g.dead = false;
+    g.frightened = false;
   });
 }
 
-function clearLines() {
-  outer: for (let y=ROWS-1;y>=0;y--) {
-    for (let x=0;x<COLS;x++) {
-      if (!board[y][x]) continue outer;
+function updateGhosts(delta) {
+  ghosts.forEach(g => {
+    if (g.dead) {
+      // move back to start
+      const dx = g.start.x * TILE - g.x;
+      const dy = g.start.y * TILE - g.y;
+      if (Math.abs(dx) < 2 && Math.abs(dy) < 2) {
+        g.dead = false;
+        g.frightened = false;
+        g.x = g.start.x * TILE;
+        g.y = g.start.y * TILE;
+      } else {
+        g.dir = { x: Math.sign(dx), y: Math.sign(dy) };
+      }
+    } else if (g.x % TILE === 0 && g.y % TILE === 0) {
+      // choose random direction
+      const options = [];
+      for (const d of [DIRS.ArrowUp, DIRS.ArrowDown, DIRS.ArrowLeft, DIRS.ArrowRight]) {
+        if (canMove(g.x + d.x * TILE, g.y + d.y * TILE) && !(g.dir.x === -d.x && g.dir.y === -d.y)) {
+          options.push(d);
+        }
+      }
+      if (options.length) {
+        g.dir = options[Math.floor(Math.random() * options.length)];
+      }
     }
-    const row = board.splice(y,1)[0].fill(0);
-    board.unshift(row);
-    lines++;
-    document.getElementById('score').textContent = `Lines: ${lines}`;
-    y++;
+    moveEntity(g, 2);
+  });
+}
+
+function checkCollisions() {
+  const pc = {x: pacman.x + TILE / 2, y: pacman.y + TILE / 2};
+  ghosts.forEach(g => {
+    if (!g.dead) {
+      const gc = {x: g.x + TILE / 2, y: g.y + TILE / 2};
+      if (Math.hypot(pc.x - gc.x, pc.y - gc.y) < TILE / 2) {
+        if (g.frightened) {
+          g.dead = true;
+          pacman.score += 200;
+        } else {
+          pacman.lives--;
+          document.getElementById('lives').textContent = `Lives: ${pacman.lives}`;
+          if (pacman.lives <= 0) {
+            playing = false;
+            document.getElementById('message').textContent = 'Game Over';
+          }
+          resetPositions();
+        }
+      }
+    }
+  });
+}
+
+function eatPellets() {
+  if (pacman.x % TILE === 0 && pacman.y % TILE === 0) {
+    const cx = pacman.x / TILE;
+    const cy = pacman.y / TILE;
+    const val = level[cy][cx];
+    if (val === 1 || val === 3) {
+      level[cy][cx] = 2;
+      remainingPellets--;
+      pacman.score += val === 3 ? 50 : 10;
+      document.getElementById('score').textContent = `Score: ${pacman.score}`;
+      if (val === 3) {
+        powerTimer = 7000;
+        ghosts.forEach(g => g.frightened = true);
+      }
+      if (remainingPellets === 0) {
+        playing = false;
+        document.getElementById('message').textContent = 'You Win!';
+      }
+    }
   }
 }
 
-function drawMatrix(matrix, offset, id) {
-  matrix.forEach((row,y)=>{
-    row.forEach((value,x)=>{
-      if (value) {
-        ctx.fillStyle = COLORS[id];
-        ctx.fillRect((x+offset.x)*BLOCK, (y+offset.y)*BLOCK, BLOCK-1, BLOCK-1);
-      }
-    });
-  });
-}
-
-function draw() {
-  ctx.fillStyle = '#000';
-  ctx.fillRect(0,0,canvas.width, canvas.height);
-  board.forEach((row,y)=>{
-    row.forEach((value,x)=>{
-      if (value) {
-        ctx.fillStyle = COLORS[value];
-        ctx.fillRect(x*BLOCK, y*BLOCK, BLOCK-1, BLOCK-1);
-      }
-    });
-  });
-  if (current) drawMatrix(current.shape, {x:current.x, y:current.y}, current.id);
-}
-
-function update(time=0) {
-  if (!playing) return;
+function update(time = 0) {
   const delta = time - lastTime;
   lastTime = time;
-  dropCounter += delta;
-  if (dropCounter > dropInterval) {
-    moveDown();
+  if (!playing) return;
+  if (powerTimer > 0) {
+    powerTimer -= delta;
+    if (powerTimer <= 0) ghosts.forEach(g => g.frightened = false);
   }
+  moveEntity(pacman, 2);
+  eatPellets();
+  updateGhosts(delta);
+  checkCollisions();
   draw();
   requestAnimationFrame(update);
 }
 
-function moveDown() {
-  current.y++;
-  if (collide(board,current)) {
-    current.y--;
-    merge(board,current);
-    clearLines();
-    spawn();
-  }
-  dropCounter = 0;
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawMap();
+  drawPacman();
+  ghosts.forEach(drawGhost);
 }
 
-function move(dir) {
-  current.x += dir;
-  if (collide(board,current)) {
-    current.x -= dir;
-  }
-}
-
-function rotatePiece() {
-  const original = current.shape;
-  current.shape = rotate(current.shape);
-  if (collide(board,current)) {
-    current.shape = original;
-  }
-}
-
-spawn();
-update();
-
-// keyboard controls
-window.addEventListener('keydown', e=>{
-  if (!playing) return;
-  switch(e.key) {
-    case 'ArrowLeft': move(-1); break;
-    case 'ArrowRight': move(1); break;
-    case 'ArrowDown': moveDown(); break;
-    case 'ArrowUp': rotatePiece(); break;
+window.addEventListener('keydown', (e) => {
+  if (DIRS[e.key]) {
+    pacman.next = DIRS[e.key];
+  } else if (e.key === ' ') {
+    playing = !playing;
+    if (playing) update();
   }
 });
 
-function handleButton(id,action) {
+// mobile controls
+function handle(id, dir) {
   const btn = document.getElementById(id);
-  ['mousedown','touchstart'].forEach(ev=>{
-    btn.addEventListener(ev,e=>{ e.preventDefault(); action(); });
-  });
+  ['touchstart', 'mousedown'].forEach(ev => btn.addEventListener(ev, (e) => {
+    e.preventDefault();
+    pacman.next = dir;
+  }));
 }
+handle('up', DIRS.ArrowUp);
+handle('down', DIRS.ArrowDown);
+handle('left', DIRS.ArrowLeft);
+handle('right', DIRS.ArrowRight);
 
-handleButton('left', ()=>move(-1));
-handleButton('right', ()=>move(1));
-handleButton('down', ()=>moveDown());
-handleButton('rotate', ()=>rotatePiece());
+draw();
+requestAnimationFrame(update);

--- a/style.css
+++ b/style.css
@@ -1,24 +1,25 @@
 body {
   background: #000;
   color: #fff;
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100vh;
-  margin: 0;
-  justify-content: center;
-  font-family: Arial, Helvetica, sans-serif;
 }
 
-#score {
-  margin-bottom: 10px;
+#hud {
+  width: 560px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
   font-size: 20px;
 }
 
 #game {
-  background: #111;
-  border: 2px solid #555;
-  touch-action: none;
+  background: #000;
+  border: 2px solid #00f;
+  margin-top: 10px;
 }
 
 #controls {
@@ -30,8 +31,8 @@ body {
   color: #fff;
   border: none;
   padding: 10px 15px;
-  margin: 0 2px;
   font-size: 18px;
+  margin: 0 2px;
 }
 
 #message {


### PR DESCRIPTION
## Summary
- convert Tetris project into a simple Pac‑Man clone
- center the canvas and add HUD for score and lives
- implement ghosts, pellets and basic collision logic
- provide mobile buttons for movement

## Testing
- `node -e "new Function(require('fs').readFileSync('script.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_688a6e646adc832d896375e1a8290d29